### PR TITLE
修复html被压缩后只能匹配出一次的bug，如：<script src=/><script src=/>

### DIFF
--- a/polyfills/ui-router-require-polyfill.js
+++ b/polyfills/ui-router-require-polyfill.js
@@ -92,7 +92,7 @@
 		 */
 		function processTpl(tpl) {
 
-			var SCRIPT_TAG_REGEX = /<script\s+((?!type=('|")text\/ng-template('|")).)*>.*<\/script>/gi,
+			var SCRIPT_TAG_REGEX = /<script\s+((?!type=('|")text\/ng-template('|")).)*?>.*?<\/script>/gi,
 				SCRIPT_SRC_REGEX = /.*\ssrc=("|')(\S+)\1.*/,
 				SCRIPT_SEQ_REGEX = /.*\sseq=("|')(\S+)\1.*/,
 				scripts = [];


### PR DESCRIPTION
# 原正则匹配如下：

![default](https://cloud.githubusercontent.com/assets/423613/17735932/a1f660da-64b7-11e6-875c-04974c0171c0.png)
# 修正后正则匹配如下：

![new](https://cloud.githubusercontent.com/assets/423613/17735977/df51a9da-64b7-11e6-9531-1b19ef7bef44.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kuitos/angular-utils/6)

<!-- Reviewable:end -->
